### PR TITLE
[SAC-1015] Address CVE-2017-17042. Bump patchlevel.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gem 'addressable', '~> 2.1'
 gem 'rake'

--- a/data_objects/Gemfile
+++ b/data_objects/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 

--- a/data_objects/data_objects.gemspec
+++ b/data_objects/data_objects.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{data_objects}
-  s.version = "0.10.17"
+  s.version = "0.10.18"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Dirkjan Bussink"]
@@ -77,7 +77,7 @@ Gem::Specification.new do |s|
     "tasks/yard.rake",
     "tasks/yardstick.rake"
   ]
-  s.homepage = %q{http://github.com/datamapper/do}
+  s.homepage = %q{https://github.com/datamapper/do}
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{dorb}
   s.rubygems_version = %q{1.6.2}
@@ -101,15 +101,15 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<addressable>, ["~> 2.1"])
       s.add_development_dependency(%q<rspec>, ["~> 2.5"])
-      s.add_development_dependency(%q<yard>, ["~> 0.5"])
+      s.add_development_dependency(%q<yard>, ["~> 0.5", ">= 0.9.20"])
     else
       s.add_dependency(%q<addressable>, ["~> 2.1"])
       s.add_dependency(%q<rspec>, ["~> 2.5"])
-      s.add_dependency(%q<yard>, ["~> 0.5"])
+      s.add_dependency(%q<yard>, ["~> 0.5", ">= 0.9.20"])
     end
   else
     s.add_dependency(%q<addressable>, ["~> 2.1"])
     s.add_dependency(%q<rspec>, ["~> 2.5"])
-    s.add_dependency(%q<yard>, ["~> 0.5"])
+    s.add_dependency(%q<yard>, ["~> 0.5", ">= 0.9.20"])
   end
 end

--- a/do_derby/Gemfile
+++ b/do_derby/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 path '../'
 

--- a/do_h2/Gemfile
+++ b/do_h2/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 path '../'
 

--- a/do_hsqldb/Gemfile
+++ b/do_hsqldb/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 path '../'
 

--- a/do_jdbc/Gemfile
+++ b/do_jdbc/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 path '../'
 

--- a/do_mysql/Gemfile
+++ b/do_mysql/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 path '../'
 

--- a/do_openedge/Gemfile
+++ b/do_openedge/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 path '../'
 

--- a/do_oracle/Gemfile
+++ b/do_oracle/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 path '../'
 

--- a/do_postgres/Gemfile
+++ b/do_postgres/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 path '../'
 

--- a/do_sqlite3/Gemfile
+++ b/do_sqlite3/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 path '../'
 

--- a/do_sqlserver/Gemfile
+++ b/do_sqlserver/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 path '../'
 


### PR DESCRIPTION
This gem is used downstream by the builder application. The affected gem, yard, isn't included in the Gemfile.lock as a dependency so this change is mostly aesthetic.

* Ensure yard >= 0.9.20 is used
* Ensure HTTPS is used when communicating with rubygems.org
* Bump minor version